### PR TITLE
Spatial Heterogeneity

### DIFF
--- a/boundaries.py
+++ b/boundaries.py
@@ -29,7 +29,7 @@ class Boundaries():
         # store boundary types (0 = vacuum, 1 = reflective)
         for surface in self._surfaces:
             for side in ['min', 'max']:
-                self._surfaces[surface][side]['type'] = 1 
+                self._surfaces[surface][side]['type'] = 0 
 
     '''
      @brief returns the coordinate of the maximum or minimum boundary for a

--- a/boundaries.py
+++ b/boundaries.py
@@ -29,10 +29,17 @@ class Boundaries():
         # store boundary types (0 = vacuum, 1 = reflective)
         for surface in self._surfaces:
             for side in ['min', 'max']:
-                self._surfaces[surface][side]['type'] = 0 
+                self._surfaces[surface][side]['type'] = 1 
 
+    '''
+     @brief returns the coordinate of the maximum or minimum boundary for a
+            given axis
+    '''
     def get_surface_coord(self, axis, side):
         return self._surfaces[axis][side]['coord']
 
+    '''
+     @brief returns the material type for a given boundary
+    '''
     def get_surface_type(self, axis, side):
         return self._surfaces[axis][side]['type']

--- a/distributions.py
+++ b/distributions.py
@@ -114,5 +114,6 @@ def sample_fission_site(fission_bank):
         point = fission_bank.location(index)
     else:
         print 'ERROR, No fission sites'
+        exit()
         point = [0,0,0]
     return point

--- a/fission.py
+++ b/fission.py
@@ -16,6 +16,9 @@ class Fission():
     def __init__(self):
         self._fission_locations = list()
     
+    '''
+     @brief clears the fission sites
+    '''
     def clear(self):
         self._fission_locations = list()
 
@@ -23,14 +26,25 @@ class Fission():
     def length(self):
         return len(self._fission_locations)
 
+    '''
+     @brief returns the first item in the fission_locations list then deletes
+            that item
+    '''
     def next(self):
         item = self._fission_locations[0]
         self._fission_locations.pop(0)
         return item
-
-    # location should be a numpy array
+ 
+    '''
+     @brief adds a location to the fission_locations list
+     @param location a numpy array of the location to be added
+    '''
     def add(self, location):
         self._fission_locations.append(location)
 
+
+    '''
+     @brief returns the location in fission_locations with index num
+    '''
     def location(self, num):
         return self._fission_locations[num]

--- a/mesh.py
+++ b/mesh.py
@@ -6,6 +6,7 @@
 '''
 
 import numpy as np
+import copy
 
 '''
  @class Mesh mesh.py "mesh.py"
@@ -13,28 +14,45 @@ import numpy as np
         core
 '''
 class Mesh():
-    def __init__(self, bounds, delta_x, delta_y, delta_z):
+    def __init__(self, bounds, delta_x = 0, delta_y=0, delta_z=0,
+            default_material='water'):
         self._delta_axes = {'x': delta_x, 'y': delta_y, 'z': delta_z}
         self._boundary_mins = {'x': bounds.get_surface_coord('x', 'min'),
                 'y': bounds.get_surface_coord('y', 'min'),
                 'z': bounds.get_surface_coord('z', 'min')}
-        self._flux = np.zeros(( \
-                (bounds.get_surface_coord('x', 'max') \
-                - self._boundary_mins['x'])/delta_x,
-                (bounds.get_surface_coord('y', 'max') \
-                - self._boundary_mins['y'])/delta_y,
-                (bounds.get_surface_coord('z', 'max') \
-                - self._boundary_mins['z'])/delta_z))
+        
+        # create flux array
+        self._axis_sizes = {'x': 0, 'y': 0, 'z': 0}
+        for i, axis in enumerate(['x', 'y', 'z']):
+            self._axis_sizes[axis] = int(( \
+                    bounds.get_surface_coord(axis, 'max') - \
+                    self._boundary_mins[axis])/self._delta_axes[axis])
 
-    def get_cell(self, position):
+        self._flux = np.zeros((self._axis_sizes['x'],
+            self._axis_sizes['y'], self._axis_sizes['z']))
+
+        # create material array
+        self._cell_materials = [[[default_material \
+                for k in range(self._axis_sizes['z'])] \
+                for j in range(self._axis_sizes['y'])]  \
+                for i in range(self._axis_sizes['x'])]
+
+    def get_cell(self, position, direction=[0,0,0]):
         cell_num_vector = list()
         for num, axis in zip(xrange(3), ['x', 'y', 'z']):
-            cell_num = int((position[num]-self._boundary_mins[axis]) \
-                    / self._delta_axes[axis])
+            cell_num = int(round((position[num]-self._boundary_mins[axis]) \
+                    / self._delta_axes[axis], 7))
 
             # correct error if neutron is on upper boundary of the geometry
             if cell_num == self._flux.shape[num]:
                 cell_num -= 1
+
+            # correct error if neutron is on upper boundary of cell
+            if position[num] == (self._boundary_mins[axis] \
+                    + cell_num*self._delta_axes[axis]) \
+                    and direction[num] < 0:
+                        cell_num -=1
+
             cell_num_vector.append(cell_num)
         return cell_num_vector
 
@@ -44,24 +62,52 @@ class Mesh():
     def flux_clear(self):
         self._flux[:][:][:] = 0
 
-    def display_flux(self, index):
-        plotter.plot_heat_map(self._flux, index)
-    
+    def display_flux(self):
+        print self._flux
+
+    def display_materials(self):
+        print self._cell_materials
+
     def get_flux(self):
         return self._flux
     
-    def get_cell_max(self, position):
-        cell_number = self.get_cell(position)
+    def get_cell_max(self, position, direction=[0,0,0]):
+        cell_number = self.get_cell(position, direction)
         maxes = dict()
-        for num, axis in zip(xrange(3), ['x', 'y', 'z']):
-            maxes.update({axis:((cell_number[num] + 1) * \
+        for i, axis in enumerate(['x', 'y', 'z']):
+            maxes.update({axis:((cell_number[i] + 1) * \
                     self._delta_axes[axis] + self._boundary_mins[axis])})
         return maxes
 
-    def get_cell_min(self, position):
-        cell_number = self.get_cell(position)
+    def get_cell_min(self, position, direction=[0,0,0]):
+        cell_number = self.get_cell(position, direction)
         mins = dict()
-        for num, axis in zip(xrange(3), ['x', 'y', 'z']):
-            mins.update({axis:(cell_number[num] * self._delta_axes[axis] \
+        for i, axis in enumerate(['x', 'y', 'z']):
+            mins.update({axis:(cell_number[i] * self._delta_axes[axis] \
                     + self._boundary_mins[axis])})
         return mins
+
+    def get_material(self, cell_number):
+        return self._cell_materials[ \
+                cell_number[0]][cell_number[1]][cell_number[2]]
+
+    # fill cells with a certain material.
+    # Locations should be a 3x2 array with the maxes and mins of the area to
+    # be filled in each dimension
+    def fill_material(self, material_type, locations):
+        x_smallest_cell = self.get_cell([locations[0][0],
+            self._boundary_mins['x'],self._boundary_mins['x']])
+        x_largest_cell = self.get_cell([locations[0][1],
+            self._boundary_mins['x'],self._boundary_mins['x']])
+        y_smallest_cell = self.get_cell([self._boundary_mins['y'],
+            locations[1][0],self._boundary_mins['y']])
+        y_largest_cell = self.get_cell([self._boundary_mins['y'],
+            locations[1][1],self._boundary_mins['y']])
+        z_smallest_cell = self.get_cell([self._boundary_mins['z'],
+            self._boundary_mins['z'],locations[2][0]])
+        z_largest_cell = self.get_cell([self._boundary_mins['z'],
+            self._boundary_mins['z'],locations[2][1]])
+        for i in range(x_smallest_cell[0], x_largest_cell[0]+1):
+            for j in range(y_smallest_cell[1], y_largest_cell[1]):
+                for k in range(z_smallest_cell[2], z_largest_cell[2]+1):
+                    self._cell_materials[i][j][k] = material_type

--- a/mesh.py
+++ b/mesh.py
@@ -95,19 +95,11 @@ class Mesh():
     # Locations should be a 3x2 array with the maxes and mins of the area to
     # be filled in each dimension
     def fill_material(self, material_type, locations):
-        x_smallest_cell = self.get_cell([locations[0][0],
-            self._boundary_mins['x'],self._boundary_mins['x']])
-        x_largest_cell = self.get_cell([locations[0][1],
-            self._boundary_mins['x'],self._boundary_mins['x']])
-        y_smallest_cell = self.get_cell([self._boundary_mins['y'],
-            locations[1][0],self._boundary_mins['y']])
-        y_largest_cell = self.get_cell([self._boundary_mins['y'],
-            locations[1][1],self._boundary_mins['y']])
-        z_smallest_cell = self.get_cell([self._boundary_mins['z'],
-            self._boundary_mins['z'],locations[2][0]])
-        z_largest_cell = self.get_cell([self._boundary_mins['z'],
-            self._boundary_mins['z'],locations[2][1]])
-        for i in range(x_smallest_cell[0], x_largest_cell[0]+1):
-            for j in range(y_smallest_cell[1], y_largest_cell[1]):
-                for k in range(z_smallest_cell[2], z_largest_cell[2]+1):
+        smallest_cell = self.get_cell( \
+                [locations[0][0], locations[1][0], locations[2][0]])
+        largest_cell = self.get_cell( \
+                [locations[0][1], locations[1][1], locations[2][1]])
+        for i in range(smallest_cell[0], largest_cell[0]+1):
+            for j in range(smallest_cell[1], largest_cell[1]):
+                for k in range(smallest_cell[2], largest_cell[2]+1):
                     self._cell_materials[i][j][k] = material_type

--- a/mesh.py
+++ b/mesh.py
@@ -37,15 +37,14 @@ class Mesh():
                 for j in range(self._axis_sizes['y'])]  \
                 for i in range(self._axis_sizes['x'])]
 
+    '''
+     @brief get the cell of a position within the geometry
+    '''
     def get_cell(self, position, direction=[0,0,0]):
         cell_num_vector = list()
-        for num, axis in zip(xrange(3), ['x', 'y', 'z']):
+        for num, axis in enumerate(['x', 'y', 'z']):
             cell_num = int(round((position[num]-self._boundary_mins[axis]) \
                     / self._delta_axes[axis], 7))
-
-            # correct error if neutron is on upper boundary of the geometry
-            if cell_num == self._flux.shape[num]:
-                cell_num -= 1
 
             # correct error if neutron is on upper boundary of cell
             if position[num] == (self._boundary_mins[axis] \
@@ -55,22 +54,41 @@ class Mesh():
 
             cell_num_vector.append(cell_num)
         return cell_num_vector
-
+    
+    '''
+     @brief add the distance a neutron has traveled within the cell to the flux
+            array
+    '''
     def flux_add(self, cell, distance):
         self._flux[cell[0]][cell[1]][cell[2]] += distance
     
+    '''
+     @brief clear the flux
+    '''
     def flux_clear(self):
         self._flux[:][:][:] = 0
 
+    '''
+     @brief print out the values in the flux array
+    '''
     def display_flux(self):
         print self._flux
 
+    '''
+     @brief print the values in the materials array
+    '''
     def display_materials(self):
         print self._cell_materials
 
+    '''
+     @brief return flux array
+    '''
     def get_flux(self):
         return self._flux
     
+    '''
+     @brief returns the coordinate for the maximum location in the cell
+    '''
     def get_cell_max(self, position, direction=[0,0,0]):
         cell_number = self.get_cell(position, direction)
         maxes = dict()
@@ -79,6 +97,9 @@ class Mesh():
                     self._delta_axes[axis] + self._boundary_mins[axis])})
         return maxes
 
+    '''
+     @brief returns the coordinate for the minimum location in the cell
+    '''
     def get_cell_min(self, position, direction=[0,0,0]):
         cell_number = self.get_cell(position, direction)
         mins = dict()
@@ -87,14 +108,23 @@ class Mesh():
                     + self._boundary_mins[axis])})
         return mins
 
+    '''
+     @brief returns the material of a given cell
+    '''
     def get_material(self, cell_number):
         return self._cell_materials[ \
                 cell_number[0]][cell_number[1]][cell_number[2]]
 
-    # fill cells with a certain material.
-    # Locations should be a 3x2 array with the maxes and mins of the area to
-    # be filled in each dimension
-    def fill_material(self, material_type, locations):
+    '''
+     @brief fill cells with a certain material
+     @param locations should be a 3x2 array with the maxes and mins of the
+            area to be filled in each dimension
+    '''
+    def fill_material(self, material_type, locations): 
+        for i, axis in enumerate(['x', 'y', 'z']):
+            if locations[i][0] == self._boundary_mins[axis] + \
+                    self._delta_axes[axis] * self._axis_sizes[axis]:
+                        locations[i][0] -= .000001
         smallest_cell = self.get_cell( \
                 [locations[0][0], locations[1][0], locations[2][0]])
         largest_cell = self.get_cell( \

--- a/mesh.py
+++ b/mesh.py
@@ -15,7 +15,7 @@ import copy
 '''
 class Mesh():
     def __init__(self, bounds, delta_x = 0, delta_y=0, delta_z=0,
-            default_material='water'):
+            default_material=None):
         self._delta_axes = {'x': delta_x, 'y': delta_y, 'z': delta_z}
         self._boundary_mins = {'x': bounds.get_surface_coord('x', 'min'),
                 'y': bounds.get_surface_coord('y', 'min'),
@@ -121,15 +121,19 @@ class Mesh():
             area to be filled in each dimension
     '''
     def fill_material(self, material_type, locations): 
+        
+        # nudge the upper limit down if it equals the geometry's upper limit
         for i, axis in enumerate(['x', 'y', 'z']):
-            if locations[i][0] == self._boundary_mins[axis] + \
-                    self._delta_axes[axis] * self._axis_sizes[axis]:
-                        locations[i][0] -= .000001
+            locations[i][1] -= self._delta_axes[axis]/10
+        
+        # put the smallest and largest cell values along each axis in a list
         smallest_cell = self.get_cell( \
                 [locations[0][0], locations[1][0], locations[2][0]])
         largest_cell = self.get_cell( \
                 [locations[0][1], locations[1][1], locations[2][1]])
+        
+        # fill the cells with material_type
         for i in range(smallest_cell[0], largest_cell[0]+1):
-            for j in range(smallest_cell[1], largest_cell[1]):
+            for j in range(smallest_cell[1], largest_cell[1]+1):
                 for k in range(smallest_cell[2], largest_cell[2]+1):
                     self._cell_materials[i][j][k] = material_type

--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -73,7 +73,7 @@ def transport_neutron(materials, bounds, tallies, fission_banks, first_round,
         
         # sample neutron distance to collision
         neutron_distance = sample_distance( \
-                materials[mesh.get_material(neutron.get_cell())])
+                mesh.get_material(neutron.get_cell()))
     
         # track neutron until collision or leakage
         while neutron_distance > 0:
@@ -162,7 +162,7 @@ def transport_neutron(materials, bounds, tallies, fission_banks, first_round,
             
         # check interaction
         if neutron.alive:
-            mat = materials[mesh.get_material(neutron.get_cell())]
+            mat = mesh.get_material(neutron.get_cell())
             neutron_interaction = sample_interaction(mat)
 
             # scattering event
@@ -186,12 +186,12 @@ def transport_neutron(materials, bounds, tallies, fission_banks, first_round,
                 tallies['absorptions'].add(1)
                 
                 # sample for fission event
-                mat = materials[mesh.get_material(neutron.get_cell())]
+                mat = mesh.get_material(neutron.get_cell())
                 if sample_fission(mat) == 1:
                     
                     # sample number of neutrons
                     for j in xrange(sample_num_fission( \
-                            materials[mesh.get_material(neutron.get_cell())])):
+                            mesh.get_material(neutron.get_cell()))):
                         fission_banks['new'].add(neutron.get_position_vector())
                         tallies['fissions'].add(1)
                 # end neutron history

--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -174,22 +174,22 @@ def transport_neutron(materials, bounds, tallies, fission_banks, first_round,
 
                 # set direction
                 neutron.set_direction(theta, phi)
-                
+
                 # reassign cell location
                 cell = mesh.get_cell(neutron.get_position_vector(),
                         neutron.get_direction_vector())
                 neutron.set_cell(cell)
             # absorption event
             else:
-               
+
                 # tally absorption
                 tallies['absorptions'].add(1)
                 
                 # sample for fission event
                 mat = materials[mesh.get_material(neutron.get_cell())]
                 if sample_fission(mat) == 1:
+                    
                     # sample number of neutrons
-
                     for j in xrange(sample_num_fission( \
                             materials[mesh.get_material(neutron.get_cell())])):
                         fission_banks['new'].add(neutron.get_position_vector())

--- a/neutron.py
+++ b/neutron.py
@@ -38,47 +38,90 @@ class Neutron():
     def alive(self):
         return self._alive
 
+    '''
+     @brief move a neutron a given distance along its direction of travel
+    '''
     def move(self, distance):
         self._xyz += self._direction * distance 
 
-    def reflect(self, surface):
-        self._direction[self.association[surface]] *= -1
+    '''
+     @brief reverse the direction of travel along a given axis
+    '''
+    def reflect(self, axis):
+        self._direction[self.association[axis]] *= -1
 
+    '''
+     @brief set the neutron's direction of travel given its angle in sphereical
+            coordinates
+    '''
     def set_direction(self, theta, phi):
         self._direction = np.array([sin(theta)*cos(phi), sin(theta)*sin(phi),
             cos(theta)])
 
+    '''
+     @brief set the neuton's position
+    '''
     def set_position(self, var, value):
         self._xyz[self.association[var]] = value
     
+    '''
+     @brief set the neutron's cell
+    '''
     def set_cell(self, cell_number):
         self._cell = cell_number
 
+    '''
+     @brief kill the neutron
+    '''
     def kill(self):
         self._alive = False
 
+    '''
+     @brief return the cell of the neutron
+    '''
     def get_cell(self):
         return self._cell
     
+    '''
+     @brief return the position of the neutron along a given axis
+    '''
     def get_position(self, var):
         return self._xyz[self.association[var]]
 
+    '''
+     @brief return the position of the neutron in all three dimensions
+    '''
     def get_position_vector(self):
         return copy(self._xyz)
     
+    '''
+     @brief return the neutron's direction of travel along a given axis
+    '''
     def get_direction(self, var):
         return self._direction[self.association[var]]
         
+    '''
+     @brief return the neutron's direction of travel in all three dimensions
+    '''
     def get_direction_vector(self):
         return copy(self._direction)
 
+    '''
+     @brief return the neutron's distance from the origin
+    '''
     def get_distance_from_origin(self):
         return sqrt(self.x**2 + self.y**2 + self.z**2)
 
+    '''
+     @brief return the neutron's distance from a given coordinate
+    '''
     def get_distance(self, coord):
         return sqrt((self.x - coord[0])**2 + (self.y - coord[1])**2 + \
                 (self.z - coord[2])**2)
 
+    '''
+     @brief return's data about the neutron
+    '''
     def __repr__(self):
         string = "<Neutron at position " + str(self._xyz) + " traveling in " \
                 + "direction " + str(self._direction) + ">"

--- a/plotter.py
+++ b/plotter.py
@@ -44,7 +44,7 @@ def plot_heat_map(flux_data, index, repeat = 100):
         for ii in range(i*repeat, (i+1)*repeat):
             for j in range(ny):
                 for jj in range(j*repeat, (j+1)*repeat):
-                    plot_array[ii, jj] = lum_img[i, j]
+                    plot_array[ii, jj] = lum_img[j, i]
     plt.imshow(plot_array, origin='lower')
     plt.colorbar()
     plt.show()

--- a/tally.py
+++ b/tally.py
@@ -14,8 +14,16 @@ import numpy as np
 class Tally():
     def __init__(self):
         self._count = 0
+    
+    '''
+     @brief add an amount to the tally
+    '''
     def add(self, amt):
         self._count += amt
+
+    '''
+     @brief cleara the tally
+    '''
     def clear(self):
         self._count = 0
     

--- a/tester.py
+++ b/tester.py
@@ -17,14 +17,25 @@ import mesh
 import plotter
 import numpy as np
 
-bounds =  boundaries.Boundaries(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
+test_bounds =  boundaries.Boundaries(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
 
-test_mesh = mesh.Mesh(bounds, .1, .1, .1)
+test_mesh = mesh.Mesh(test_bounds, .1, .1, .1, default_material='water')
 
-test_material = material.Material(sigma_t=2.0, sigma_s=1.0, nu=2.4, sigma_f=.5)
+# create test materials
+fuel_material = material.Material(sigma_t=2.0, sigma_s=1.0,
+        nu=2.4, sigma_f=.5)
+water_material = material.Material(sigma_t=2.0, sigma_s=1.0,
+        nu=2.4, sigma_f=0.0)
+test_materials = {'fuel': fuel_material, 'water': water_material}
 
-monte_carlo.generate_neutron_histories(n_histories=100000, mat=test_material, 
-        bounds=bounds, mesh=test_mesh, num_batches=1)
+# fill mesh with some fuel
+test_mesh.fill_material('fuel', [[-.5,1.0],[-1.0,0.0],[-1.0,1.0]])
 
-index = 9
+# run simulation
+monte_carlo.generate_neutron_histories(n_histories=10000, 
+        materials = test_materials, bounds=test_bounds, mesh=test_mesh,
+        num_batches=5)
+
+# display plot of neutron flux
+index = 2
 plotter.plot_heat_map(test_mesh.get_flux(), index, repeat = 50)

--- a/tester.py
+++ b/tester.py
@@ -17,9 +17,9 @@ import mesh
 import plotter
 import numpy as np
 
-test_bounds =  boundaries.Boundaries(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
+test_bounds =  boundaries.Boundaries(-10.0, 10.0, -10.0, 10.0, -1.00, 10.0)
 
-test_mesh = mesh.Mesh(test_bounds, .1, .1, .1, default_material='water')
+test_mesh = mesh.Mesh(test_bounds, 1, 1, 1, default_material='water')
 
 # create test materials
 fuel_material = material.Material(sigma_t=2.0, sigma_s=1.0,
@@ -29,13 +29,18 @@ water_material = material.Material(sigma_t=2.0, sigma_s=1.0,
 test_materials = {'fuel': fuel_material, 'water': water_material}
 
 # fill mesh with some fuel
-test_mesh.fill_material('fuel', [[-.5,1.0],[-1.0,0.0],[-1.0,1.0]])
+test_mesh.fill_material('fuel', [[-6.0, -5.0],[-6.0,-5.0],[-10.0,9.0]])
+test_mesh.fill_material('fuel', [[-6.0, -5.0],[-3.0,-2.0],[-10.0,9.0]])
+test_mesh.fill_material('fuel', [[-6.0, -5.0],[0.0,1.0],[-10.0,9.0]])
+test_mesh.fill_material('fuel', [[5.0, 6.0],[-6.0,-5.0],[-10.0,9.0]])
+test_mesh.fill_material('fuel', [[5.0, 6.0],[-3.0,-2.0],[-10.0,9.0]])
+test_mesh.fill_material('fuel', [[5.0, 6.0],[0.0,-1.0],[-10.0,9.0]])
 
 # run simulation
 monte_carlo.generate_neutron_histories(n_histories=10000, 
         materials = test_materials, bounds=test_bounds, mesh=test_mesh,
-        num_batches=5)
+        num_batches=3)
 
 # display plot of neutron flux
 index = 2
-plotter.plot_heat_map(test_mesh.get_flux(), index, repeat = 50)
+plotter.plot_heat_map(test_mesh.get_flux(), index, repeat = 5)

--- a/tester.py
+++ b/tester.py
@@ -17,28 +17,37 @@ import mesh
 import plotter
 import numpy as np
 
-test_bounds =  boundaries.Boundaries(-10.0, 10.0, -10.0, 10.0, -1.00, 10.0)
-
-test_mesh = mesh.Mesh(test_bounds, 1, 1, 1, default_material='water')
-
 # create test materials
 fuel_material = material.Material(sigma_t=2.0, sigma_s=1.0,
         nu=2.4, sigma_f=.5)
-water_material = material.Material(sigma_t=2.0, sigma_s=1.0,
+water = material.Material(sigma_t=2.0, sigma_s=1.0,
         nu=2.4, sigma_f=0.0)
-test_materials = {'fuel': fuel_material, 'water': water_material}
+
+test_bounds =  boundaries.Boundaries(-10.0, 10.0, -10.0, 10.0, -10.00, 10.0)
+
+test_mesh = mesh.Mesh(test_bounds, 1.0, 1.0, 1.0, default_material=None)
 
 # fill mesh with some fuel
-test_mesh.fill_material('fuel', [[-6.0, -5.0],[-6.0,-5.0],[-10.0,9.0]])
-test_mesh.fill_material('fuel', [[-6.0, -5.0],[-3.0,-2.0],[-10.0,9.0]])
-test_mesh.fill_material('fuel', [[-6.0, -5.0],[0.0,1.0],[-10.0,9.0]])
-test_mesh.fill_material('fuel', [[5.0, 6.0],[-6.0,-5.0],[-10.0,9.0]])
-test_mesh.fill_material('fuel', [[5.0, 6.0],[-3.0,-2.0],[-10.0,9.0]])
-test_mesh.fill_material('fuel', [[5.0, 6.0],[0.0,-1.0],[-10.0,9.0]])
+test_mesh.fill_material(fuel_material, [[-6.0, -5.0],[-6.0,-5.0],[-10.0,10.0]])
+test_mesh.fill_material(fuel_material, [[-6.0, -5.0],[-3.0,-2.0],[-10.0,10.0]])
+test_mesh.fill_material(fuel_material, [[-6.0, -5.0],[0.0,1.0],[-10.0,10.0]])
+test_mesh.fill_material(fuel_material, [[5.0, 6.0],[-6.0,-5.0],[-10.0,10.0]])
+test_mesh.fill_material(fuel_material, [[5.0, 6.0],[-3.0,-2.0],[-10.0,10.0]])
+test_mesh.fill_material(fuel_material, [[5.0, 6.0],[0.0,1.0],[-10.0,10.0]])
+
+# fill the rest of the mesh with water
+test_mesh.fill_material(water, [[-10.0, 10.0],[-10.0, -6.0],[-10.0,10.0]])
+test_mesh.fill_material(water, [[-10.0, 10.0],[-5.0, -3.0],[-10.0,10.0]])
+test_mesh.fill_material(water, [[-10.0, 10.0],[-2.0, 0.0],[-10.0,10.0]])
+test_mesh.fill_material(water, [[-10.0, 10.0],[1.0, 10.0],[-10.0,10.0]])
+
+test_mesh.fill_material(water, [[-10.0, -6.0],[-10.0, 10.0],[-10.0,10.0]])
+test_mesh.fill_material(water, [[-5.0, 5.0],[-10.0, 10.0],[-10.0,10.0]])
+test_mesh.fill_material(water, [[6.0, 10.0],[-10.0, 10.0],[-10.0,10.0]])
 
 # run simulation
 monte_carlo.generate_neutron_histories(n_histories=10000, 
-        materials = test_materials, bounds=test_bounds, mesh=test_mesh,
+        bounds=test_bounds, mesh=test_mesh,
         num_batches=3)
 
 # display plot of neutron flux


### PR DESCRIPTION
The mesh class can now be passed a material type. Different cells can be filled with different types of material. When a mesh is initialized, it can be passed a material to be set for all the cells. If no material is passed, all the cells are set to material type 'water'.

The material of certain sections of the box can be changed with the function 'fill_material()'.

Previously monte_carlo.py ran into trouble when a neutron was on the upper edge of a cell. For example, in an mesh from -1 to 1 with delta_x = .1, when a neutron was at x=-.9, it should have been counted as in cell x=0 if its direction of movement was into cell x=0. The previous code counted it as in cell x=1, however. We tried to overcome that by nudging the neutron, but that must not have been implemented properly because it wasn't working. I added in code in mesh.py that simply checks the direction of travel of the neutron in the case that it's on the lower boundary of a cell. There are almost certainly more elegant solutions to this problem, but this is the only one I could get to work.

The plotter was plotting the heat map on with the axes switched. I fixed that.
