### PR TITLE
Multigroup handling

### DIFF
--- a/distributions.py
+++ b/distributions.py
@@ -51,8 +51,8 @@ def sample_incorrect_polar_angle():
  @param     mat a Material object that contains information about the material
  @return    A randomly sampled distance in [0, infinity)
 '''
-def sample_distance(mat):
-    return -log(random.random()) / mat.sigma_t
+def sample_distance(mat, group):
+    return -log(random.random()) / mat.sigma_t[group]
 
 '''
  @brief     Function that samples the interaction type (0 = scattering,
@@ -63,8 +63,8 @@ def sample_distance(mat):
             about the material            
  @return    An interaction type (0 = scattering, 1 = absorption)
 '''
-def sample_interaction(mat):
-    return int(random.random() < mat.sigma_s / mat.sigma_t)
+def sample_interaction(mat, g, new_g):
+    return int(random.random() < mat.sigma_s[g][new_g] / mat.sigma_t[g])
 
 '''
  @brief     Function that samples a random location within a bounding box.
@@ -90,8 +90,11 @@ def sample_location(bounds):
  @param     mat a Material object that contains information about the material
  @return    An interaction type (0 = capture, 1 = fission)
 '''
-def sample_fission(mat):
-    return int(random.random() < mat.sigma_f / mat.sigma_a)
+def sample_fission(mat, g, new_g):
+
+    # I'm not sure if I'm using the right item in sigma_s
+    return int(random.random() < mat.sigma_f[g] \
+            / (mat.sigma_t[g]-mat.sigma_s[g][new_g]))
 
 '''
  @brief     Samples the nunber of neutrons produced from a fission event

--- a/distributions.py
+++ b/distributions.py
@@ -63,8 +63,8 @@ def sample_distance(mat, group):
             about the material            
  @return    An interaction type (0 = scattering, 1 = absorption)
 '''
-def sample_interaction(mat, g, new_g):
-    return int(random.random() < mat.sigma_s[g][new_g] / mat.sigma_t[g])
+def sample_interaction(mat, g):
+    return int(random.random() < sum(mat.sigma_s[g]) / mat.sigma_t[g])
 
 '''
  @brief     Function that samples a random location within a bounding box.
@@ -90,11 +90,8 @@ def sample_location(bounds):
  @param     mat a Material object that contains information about the material
  @return    An interaction type (0 = capture, 1 = fission)
 '''
-def sample_fission(mat, g, new_g):
-
-    # I'm not sure if I'm using the right item in sigma_s
-    return int(random.random() < mat.sigma_f[g] \
-            / (mat.sigma_t[g]-mat.sigma_s[g][new_g]))
+def sample_fission(mat, g):
+    return int(random.random() < mat.sigma_f[g] / mat.sigma_a[g])
 
 '''
  @brief     Samples the nunber of neutrons produced from a fission event
@@ -121,7 +118,6 @@ def sample_fission_site(fission_bank):
         point = [0,0,0]
     return point
 
-
 '''
  @brief     Samples an initial neutron energy group after fission
  @param     chi the neutron emission spectrum from fission
@@ -141,14 +137,13 @@ def sample_neutron_energy_group(chi):
 
     return len(chi) - 1
 
-
 '''
  @brief     Samples the neutron energy group after a scattering event
  @param     g the neutron energy group before scattering
  @param     scattering_matrix the scattering cross section matrix
  @return    the neutron group after scattering
 '''
-def sample_scattered_group(g, scattering_matrix):
+def sample_scattered_group(scattering_matrix, g):
     
     # sample random number 
     r = random.random() * sum(scattering_matrix[g])

--- a/material.py
+++ b/material.py
@@ -25,10 +25,6 @@ class Material:
         # fission cross-section
         self._sigma_f = sigma_f
 
-        # absorption cross-section
-        self._sigma_a = sigma_t - sigma_s
-
-
     # functions to allow access to the values stored in Material
     @property
     def sigma_t(self):

--- a/material.py
+++ b/material.py
@@ -11,7 +11,7 @@
             nulcear data (i.e. cross-sections) for neutron transport.
 '''
 class Material:
-    def __init__(self, sigma_t=0, sigma_s=0, nu=0, sigma_f=0, chi=0):
+    def __init__(self, sigma_t, sigma_s, nu, sigma_f, chi):
         
         # total cross-section
         self._sigma_t = sigma_t

--- a/material.py
+++ b/material.py
@@ -11,7 +11,7 @@
             nulcear data (i.e. cross-sections) for neutron transport.
 '''
 class Material:
-    def __init__(self, sigma_t=0, sigma_s=0, nu=0, sigma_f=0):
+    def __init__(self, sigma_t=0, sigma_s=0, nu=0, sigma_f=0, chi=0):
         
         # total cross-section
         self._sigma_t = sigma_t
@@ -24,6 +24,14 @@ class Material:
 
         # fission cross-section
         self._sigma_f = sigma_f
+        
+        # chi
+        self._chi = chi
+        
+        # absorption cross-section
+        self._sigma_a = list()
+        for i in range(len(sigma_t)):
+            self._sigma_a.append(sigma_t[i] - sum(sigma_s[i]))
 
     # functions to allow access to the values stored in Material
     @property
@@ -45,3 +53,7 @@ class Material:
     @property
     def sigma_a(self):
         return self._sigma_a
+
+    @property
+    def chi(self):
+        return self._chi

--- a/mesh.py
+++ b/mesh.py
@@ -14,8 +14,8 @@ import copy
         core
 '''
 class Mesh():
-    def __init__(self, bounds, delta_x = 0, delta_y=0, delta_z=0,
-            default_material=None, num_groups=0):
+    def __init__(self, bounds, delta_x, delta_y, delta_z, num_groups,
+            default_material=None):
         self._delta_axes = {'x': delta_x, 'y': delta_y, 'z': delta_z}
         self._boundary_mins = {'x': bounds.get_surface_coord('x', 'min'),
                 'y': bounds.get_surface_coord('y', 'min'),
@@ -61,7 +61,7 @@ class Mesh():
      @brief add the distance a neutron has traveled within the cell to the flux
             array
     '''
-    def flux_add(self, group, cell, distance):
+    def flux_add(self, cell, distance, group):
         self._flux[group][cell[0]][cell[1]][cell[2]] += distance
     
     '''

--- a/mesh.py
+++ b/mesh.py
@@ -15,7 +15,7 @@ import copy
 '''
 class Mesh():
     def __init__(self, bounds, delta_x = 0, delta_y=0, delta_z=0,
-            default_material=None):
+            default_material=None, num_groups=0):
         self._delta_axes = {'x': delta_x, 'y': delta_y, 'z': delta_z}
         self._boundary_mins = {'x': bounds.get_surface_coord('x', 'min'),
                 'y': bounds.get_surface_coord('y', 'min'),
@@ -28,8 +28,10 @@ class Mesh():
                     bounds.get_surface_coord(axis, 'max') - \
                     self._boundary_mins[axis])/self._delta_axes[axis])
 
-        self._flux = np.zeros((self._axis_sizes['x'],
+        self._flux = np.zeros((num_groups, self._axis_sizes['x'],
             self._axis_sizes['y'], self._axis_sizes['z']))
+
+        
 
         # create material array
         self._cell_materials = [[[default_material \
@@ -59,14 +61,14 @@ class Mesh():
      @brief add the distance a neutron has traveled within the cell to the flux
             array
     '''
-    def flux_add(self, cell, distance):
-        self._flux[cell[0]][cell[1]][cell[2]] += distance
+    def flux_add(self, group, cell, distance):
+        self._flux[group][cell[0]][cell[1]][cell[2]] += distance
     
     '''
      @brief clear the flux
     '''
     def flux_clear(self):
-        self._flux[:][:][:] = 0
+        self._flux[:][:][:][:] = 0
 
     '''
      @brief print out the values in the flux array

--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -68,7 +68,7 @@ def transport_neutron(bounds, tallies, fission_banks, first_round,
     neutron.set_cell(cell)
     
     # set neutron group
-    cell_mat = mesh.get_material(neutron.get_cell())
+    cell_mat = mesh.get_material(cell)
     group = sample_neutron_energy_group(cell_mat.chi)
     neutron.set_group(group)
     axes = ['x','y', 'z']
@@ -170,8 +170,7 @@ def transport_neutron(bounds, tallies, fission_banks, first_round,
             mat = mesh.get_material(neutron.get_cell())
 
             # sample what the interaction will be
-            neutron_interaction = sample_interaction(mat,
-                    neutron.group)
+            neutron_interaction = sample_interaction(mat, neutron.group)
 
             # scattering event
             if neutron_interaction == 0:
@@ -228,8 +227,7 @@ def transport_neutron(bounds, tallies, fission_banks, first_round,
  @param     mesh a Mesh object containing information about the mesh
  @param     num_batches the number of batches to be tested
 '''
-def generate_neutron_histories(n_histories, bounds,
-        mesh, num_batches):
+def generate_neutron_histories(n_histories, bounds, mesh, num_batches):
     
     crow_distances = tally.Tally()
     num_crow_distances = tally.Tally()

--- a/neutron.py
+++ b/neutron.py
@@ -14,11 +14,11 @@ from copy import deepcopy as copy
  @brief Contains neutron position and direction information
 '''
 class Neutron():
-    def __init__(self, position, theta, phi):
+    def __init__(self, position, theta, phi, group):
         
         self._xyz = np.array(copy(position))
         self._alive = True
-        
+        self._group = group
         self.set_direction(theta, phi)
         self.association = {'x': 0, 'y':1, 'z':2}
 
@@ -38,6 +38,9 @@ class Neutron():
     def alive(self):
         return self._alive
 
+    @property
+    def group(self):
+        return self._group
     '''
      @brief move a neutron a given distance along its direction of travel
     '''
@@ -127,3 +130,8 @@ class Neutron():
                 + "direction " + str(self._direction) + ">"
         return string
 
+    '''
+     @brief set the neutron's energy group
+    '''
+    def set_group(self, new_group):
+        self._group = new_group

--- a/neutron.py
+++ b/neutron.py
@@ -14,11 +14,10 @@ from copy import deepcopy as copy
  @brief Contains neutron position and direction information
 '''
 class Neutron():
-    def __init__(self, position, theta, phi, group):
+    def __init__(self, position, theta, phi):
         
         self._xyz = np.array(copy(position))
         self._alive = True
-        self._group = group
         self.set_direction(theta, phi)
         self.association = {'x': 0, 'y':1, 'z':2}
 

--- a/plotter.py
+++ b/plotter.py
@@ -30,7 +30,7 @@ def plot_3D_points(xdata, ydata, zdata):
  @param     flux_data a 3d numpy array containing the flux information
  @param     index the z cell-value at which the heat map is displayed
 '''
-def plot_heat_map(flux_data, index, repeat = 100):
+def plot_heat_map(flux_data, index, repeat = 100, title=''):
 
     img = flux_data
     lum_img = img[:, :, index]
@@ -47,4 +47,5 @@ def plot_heat_map(flux_data, index, repeat = 100):
                     plot_array[ii, jj] = lum_img[j, i]
     plt.imshow(plot_array, origin='lower')
     plt.colorbar()
-    plt.show()
+    plt.title(title)
+    plt.show(title)

--- a/tester.py
+++ b/tester.py
@@ -61,10 +61,11 @@ test_mesh.fill_material(water, [[6.0, 10.0],[-10.0, 10.0],[-10.0,10.0]])
 # run simulation
 monte_carlo.generate_neutron_histories(n_histories=10000, 
         bounds=test_bounds, mesh=test_mesh,
-        num_batches=4, chi=test_chi)
+        num_batches=2, chi=test_chi)
 
 # display plot of neutron flux
 index = 2
 flux_to_plot = test_mesh.get_flux()
 for i in range(test_num_groups):
-    plotter.plot_heat_map(flux_to_plot[i], index, repeat = 5)
+    plotter.plot_heat_map(flux_to_plot[i], index, repeat = 5,
+            title = ('Group ' + str(i+1)))

--- a/tester.py
+++ b/tester.py
@@ -17,15 +17,28 @@ import mesh
 import plotter
 import numpy as np
 
+
+# define chi
+test_chi = [.6, .3, .1]
+
+# create cross sections
+test_num_groups = 3
+test_sigma_s = [[.8,1.0,1.2],[.7,.9,1.4],[.9,1.0,1.1]]
+test_sigma_t = list()
+for i in range(len(test_sigma_s)):
+    test_sigma_t.append(sum(test_sigma_s[i]))
+test_sigma_f = [.4,.3,.2]
+
 # create test materials
-fuel_material = material.Material(sigma_t=2.0, sigma_s=1.0,
-        nu=2.4, sigma_f=.5)
-water = material.Material(sigma_t=2.0, sigma_s=1.0,
-        nu=2.4, sigma_f=0.0)
+fuel_material = material.Material(sigma_t= test_sigma_t, sigma_s=test_sigma_s,
+        nu=2.4, sigma_f= test_sigma_f)
+water = material.Material(sigma_t= test_sigma_t, sigma_s=test_sigma_s,
+        nu=2.4, sigma_f=[0.0, 0.0, 0.0])
 
 test_bounds =  boundaries.Boundaries(-10.0, 10.0, -10.0, 10.0, -10.00, 10.0)
 
-test_mesh = mesh.Mesh(test_bounds, 1.0, 1.0, 1.0, default_material=None)
+test_mesh = mesh.Mesh(test_bounds, 1.0, 1.0, 1.0, default_material=None,
+        num_groups = test_num_groups)
 
 # fill mesh with some fuel
 test_mesh.fill_material(fuel_material, [[-6.0, -5.0],[-6.0,-5.0],[-10.0,10.0]])
@@ -48,8 +61,10 @@ test_mesh.fill_material(water, [[6.0, 10.0],[-10.0, 10.0],[-10.0,10.0]])
 # run simulation
 monte_carlo.generate_neutron_histories(n_histories=10000, 
         bounds=test_bounds, mesh=test_mesh,
-        num_batches=3)
+        num_batches=4, chi=test_chi)
 
 # display plot of neutron flux
 index = 2
-plotter.plot_heat_map(test_mesh.get_flux(), index, repeat = 5)
+flux_to_plot = test_mesh.get_flux()
+for i in range(test_num_groups):
+    plotter.plot_heat_map(flux_to_plot[i], index, repeat = 5)

--- a/tester.py
+++ b/tester.py
@@ -24,21 +24,19 @@ test_chi = [.6, .3, .1]
 # create cross sections
 test_num_groups = 3
 test_sigma_s = [[.8,1.0,1.2],[.7,.9,1.4],[.9,1.0,1.1]]
-test_sigma_t = list()
-for i in range(len(test_sigma_s)):
-    test_sigma_t.append(sum(test_sigma_s[i]))
+test_sigma_t = [4.0, 4.0, 4.0]
 test_sigma_f = [.4,.3,.2]
 
 # create test materials
 fuel_material = material.Material(sigma_t= test_sigma_t, sigma_s=test_sigma_s,
-        nu=2.4, sigma_f= test_sigma_f)
+        nu=2.4, sigma_f= test_sigma_f, chi = test_chi)
 water = material.Material(sigma_t= test_sigma_t, sigma_s=test_sigma_s,
-        nu=2.4, sigma_f=[0.0, 0.0, 0.0])
+        nu=2.4, sigma_f=[0.0, 0.0, 0.0], chi = test_chi)
 
 test_bounds =  boundaries.Boundaries(-10.0, 10.0, -10.0, 10.0, -10.00, 10.0)
 
-test_mesh = mesh.Mesh(test_bounds, 1.0, 1.0, 1.0, default_material=None,
-        num_groups = test_num_groups)
+test_mesh = mesh.Mesh(test_bounds, 1.0, 1.0, 1.0, num_groups = test_num_groups,
+        default_material=None)
 
 # fill mesh with some fuel
 test_mesh.fill_material(fuel_material, [[-6.0, -5.0],[-6.0,-5.0],[-10.0,10.0]])
@@ -61,7 +59,7 @@ test_mesh.fill_material(water, [[6.0, 10.0],[-10.0, 10.0],[-10.0,10.0]])
 # run simulation
 monte_carlo.generate_neutron_histories(n_histories=10000, 
         bounds=test_bounds, mesh=test_mesh,
-        num_batches=2, chi=test_chi)
+        num_batches=2)
 
 # display plot of neutron flux
 index = 2


### PR DESCRIPTION
I added handling of neutrons in different energy groups. The groups are plotted separately by plotter.py.

sigma_s was changed to a 2-d array holding the scattering matrix. sigma_t was changed to a list containing the total cross section for each group. I added handling of these values to distributions.py and mesh.py.

I added the value 'group' to the Neutron class to keep track of what group each neutron was in.

The Mesh class keeps track of the fluxes for each group separately.

I added the value Chi to determine what group neutrons are born into.
